### PR TITLE
dev: fix: Avoid old attribute.

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -38,4 +38,8 @@ services:
 
 volumes:
   extensions:
+    external: true
+    name: devcontainer_extensions
   go:
+    external: true
+    name: devcontainer_go1.21

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.8"
 
 services:
   dev:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -19,8 +19,6 @@ services:
       - type: volume
         source: extensions
         target: /home/vscode/.vscode-server/extensions
-        volume:
-          nocopy: true
       - type: bind
         source: .bash
         target: /home/vscode/.cache/bash
@@ -28,8 +26,6 @@ services:
       - type: volume
         source: go
         target: /home/vscode/go
-        volume:
-          nocopy: true
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
@@ -42,8 +38,4 @@ services:
 
 volumes:
   extensions:
-    external:
-      name: devcontainer_extensions
   go:
-    external:
-      name: devcontainer_go1.21


### PR DESCRIPTION
> external.name was deprecated in version 3.5 file format use name instead.

https://docs.docker.com/compose/compose-file/compose-file-v3/#external-1