### PR TITLE
日時文字列の構築をライブラリ側が行うように変更

### DIFF
--- a/employee.go
+++ b/employee.go
@@ -342,22 +342,24 @@ func (c *Client) CreateEmployee(req *CreateEmployeeRequest) (Employee, error) {
 }
 
 type UpdateEmployeeRequest struct {
-	CompanyID int  `json:"company_id"`
-	Year      *int `json:"year,omitempty"`
-	Month     *int `json:"month,omitempty"`
-	Employee  struct {
-		Num                                *string `json:"num,omitempty"`
-		DisplayName                        *string `json:"display_name,omitempty"`
-		BasePensionNum                     *string `json:"base_pension_num,omitempty"`
-		EmploymentInsuranceReferenceNumber *string `json:"employment_insurance_reference_number,omitempty"`
-		BirthDate                          string  `json:"birth_date"`
-		EntryDate                          string  `json:"entry_date"`
-		RetireDate                         *string `json:"retire_date,omitempty"`
-		CompanyReferenceDateRuleName       *string `json:"company_reference_date_rule_name,omitempty"`
-	} `json:"employee"`
+	CompanyID int                           `json:"company_id"`
+	Year      *int                          `json:"year,omitempty"`
+	Month     *int                          `json:"month,omitempty"`
+	Employee  UpdateEmployeeRequestEmployee `json:"employee"`
 }
 
-// CreateEmployee は従業員を新規作成します。
+type UpdateEmployeeRequestEmployee struct {
+	Num                                string `json:"num,omitempty"`
+	DisplayName                        string `json:"display_name,omitempty"`
+	BasePensionNum                     string `json:"base_pension_num,omitempty"`
+	EmploymentInsuranceReferenceNumber string `json:"employment_insurance_reference_number,omitempty"`
+	BirthDate                          Date   `json:"birth_date"`
+	EntryDate                          Date   `json:"entry_date"`
+	RetireDate                         *Date  `json:"retire_date,omitempty"`
+	CompanyReferenceDateRuleName       string `json:"company_reference_date_rule_name,omitempty"`
+}
+
+// UpdateEmployee は指定した従業員の情報を更新します。
 // 注意点
 // - 管理者権限を持ったユーザーのみ実行可能です。
 func (c *Client) UpdateEmployee(employeeID int, request *UpdateEmployeeRequest) (Employee, error) {

--- a/employee.go
+++ b/employee.go
@@ -300,23 +300,25 @@ func (c *Client) GetEmployee(companyID int, employeeID int, year int, month int)
 }
 
 type CreateEmployeeRequest struct {
-	CompanyID int `json:"company_id"`
-	Employee  struct {
-		Num                          *string `json:"num,omitempty"`
-		WorkingHoursSystemName       *string `json:"working_hours_system_name,omitempty"`
-		CompanyReferenceDateRuleName *string `json:"company_reference_date_rule_name,omitempty"`
-		LastName                     string  `json:"last_name"`
-		FirstName                    string  `json:"first_name"`
-		LastNameKana                 string  `json:"last_name_kana"`
-		FirstNameKana                string  `json:"first_name_kana"`
-		BirthDate                    string  `json:"birth_date"`
-		EntryDate                    string  `json:"entry_date"`
-		PayCalcType                  *string `json:"pay_calc_type,omitempty"`
-		PayAmount                    *int    `json:"pay_amount,omitempty"`
-		Gender                       *string `json:"gender,omitempty"`
-		Married                      *bool   `json:"married,omitempty"`
-		NoPayrollCalculation         *bool   `json:"no_payroll_calculation,omitempty"`
-	} `json:"employee"`
+	CompanyID int                           `json:"company_id"`
+	Employee  CreateEmployeeRequestEmployee `json:"employee"`
+}
+
+type CreateEmployeeRequestEmployee struct {
+	Num                          string `json:"num,omitempty"`
+	WorkingHoursSystemName       string `json:"working_hours_system_name,omitempty"`
+	CompanyReferenceDateRuleName string `json:"company_reference_date_rule_name,omitempty"`
+	LastName                     string `json:"last_name"`
+	FirstName                    string `json:"first_name"`
+	LastNameKana                 string `json:"last_name_kana"`
+	FirstNameKana                string `json:"first_name_kana"`
+	BirthDate                    Date   `json:"birth_date"`
+	EntryDate                    Date   `json:"entry_date"`
+	PayCalcType                  string `json:"pay_calc_type,omitempty"`
+	PayAmount                    *int   `json:"pay_amount,omitempty"`
+	Gender                       string `json:"gender,omitempty"`
+	Married                      *bool  `json:"married,omitempty"`
+	NoPayrollCalculation         *bool  `json:"no_payroll_calculation,omitempty"`
 }
 
 // CreateEmployee は従業員を新規作成します。

--- a/timeclock.go
+++ b/timeclock.go
@@ -84,7 +84,7 @@ type AvailableTypes struct {
 }
 
 type GetAvailableTypesOpts struct {
-	Date string // 従業員情報を取得したい年月日(YYYY-MM-DD)(例:2018-08-01)(デフォルト：当日)
+	Date *Date // 従業員情報を取得したい年月日(YYYY-MM-DD)(例:2018-08-01)(デフォルト：当日)
 }
 
 // GetAvailableTypes は指定した従業員・日付の打刻可能種別と打刻基準日を返します。
@@ -95,8 +95,8 @@ func (c *Client) GetAvailableTypes(companyID int, employeeID int, opts *GetAvail
 		"company_id": {strconv.Itoa(companyID)},
 	}
 	if opts != nil {
-		if opts.Date != "" {
-			q.Set("date", opts.Date)
+		if opts.Date != nil {
+			q.Set("date", opts.Date.String())
 		}
 	}
 	resp, err := c.do(http.MethodGet, u, q, nil)

--- a/timeclock.go
+++ b/timeclock.go
@@ -113,10 +113,10 @@ func (c *Client) GetAvailableTypes(companyID int, employeeID int, opts *GetAvail
 }
 
 type CreateTimeClockRequest struct {
-	CompanyID int     `json:"company_id"`
-	Type      string  `json:"type"`
-	BaseDate  *string `json:"base_date,omitempty"`
-	Datetime  *string `json:"datetime,omitempty"`
+	CompanyID int       `json:"company_id"`
+	Type      string    `json:"type"`
+	BaseDate  *Date     `json:"base_date,omitempty"`
+	Datetime  *DateTime `json:"datetime,omitempty"`
 }
 
 // CreateTimeClock は指定した従業員の打刻情報を登録します。

--- a/timeclock.go
+++ b/timeclock.go
@@ -4,25 +4,24 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 )
 
 // https://developer.freee.co.jp/reference/hr/reference#operations-tag-タイムレコーダー(打刻)
 
 type TimeClock struct {
-	ID               int       `json:"id"`
-	Date             string    `json:"date"`
-	Type             string    `json:"type"`
-	Datetime         time.Time `json:"datetime"`
-	OriginalDatetime time.Time `json:"original_datetime"`
-	Note             string    `json:"note"`
+	ID               int    `json:"id"`
+	Date             string `json:"date"`
+	Type             string `json:"type"`
+	Datetime         string `json:"datetime"`
+	OriginalDatetime string `json:"original_datetime"`
+	Note             string `json:"note"`
 }
 
 type ListTimeClocksOps struct {
-	FromDate string // 取得する打刻期間の開始日(YYYY-MM-DD)(例:2018-08-01)(デフォルト: 当月の打刻開始日)
-	ToDate   string // 取得する打刻期間の終了日(YYYY-MM-DD)(例:2018-08-31)(デフォルト: 当日)
-	Limit    int    // 取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)
-	Offset   int    // 取得レコードのオフセット (デフォルト: 0)
+	FromDate *Date // 取得する打刻期間の開始日(YYYY-MM-DD)(例:2018-08-01)(デフォルト: 当月の打刻開始日)
+	ToDate   *Date // 取得する打刻期間の終了日(YYYY-MM-DD)(例:2018-08-31)(デフォルト: 当日)
+	Limit    int   // 取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)
+	Offset   int   // 取得レコードのオフセット (デフォルト: 0)
 }
 
 // ListTimeClocks は指定した従業員・期間の打刻情報を返します。
@@ -32,17 +31,17 @@ func (c *Client) ListTimeClocks(companyID int, employeeID int, opts *ListTimeClo
 		"company_id": {strconv.Itoa(companyID)},
 	}
 	if opts != nil {
-		if opts.FromDate != "" {
-			q.Set("from_date", opts.FromDate)
+		if opts.FromDate != nil {
+			q.Set("from_date", opts.FromDate.String())
 		}
-		if opts.ToDate != "" {
-			q.Set("to_date", opts.ToDate)
+		if opts.ToDate != nil {
+			q.Set("to_date", opts.ToDate.String())
 		}
-		if opts.Limit != 50 {
+		if opts.Limit > 0 {
 			q.Set("limit", strconv.Itoa(opts.Limit))
 		}
 		if opts.Offset > 0 {
-			q.Set("offset", strconv.Itoa(opts.Limit))
+			q.Set("offset", strconv.Itoa(opts.Offset))
 		}
 	}
 	resp, err := c.do(http.MethodGet, u, q, nil)


### PR DESCRIPTION
すべてのリクエスト関数について`Date`, `DateTime`を使うように変更。
そのうえでテストを行い、見つけた問題を修正

- 空文字列が意味をもたないフィールドは`*string`ではなく`string`を使うように変更
- ユーザが構築する構造体に名前をつけ、自動補完が適切に効くように修正
- その他単純ミスを修正。`Offset`を与えるべきところに`Limit`が渡されたりとか