### PR TITLE
fix server panic

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -101,8 +101,10 @@ func Authorize(clientID string, port int, opts ...OptFunc) (string, error) {
 
 				o.Renderer(w, tAuthorizationCode, err)
 
-				resultCh <- Result{tAuthorizationCode, err}
-				shutdownCh <- struct{}{}
+				if err == nil {
+					resultCh <- Result{tAuthorizationCode, err}
+					shutdownCh <- struct{}{}
+				}
 			}),
 		}
 		go func() {


### PR DESCRIPTION
アクセストークンを取得する際、
ブラウザで許可するを押した後、認証が完了したときに
ランダムにターミナルでは以下のエラーが発生するのでその対策
```
2024/02/11 12:07:32 http: panic serving [::1]:47878: send on closed channel
goroutine 19 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1868 +0xb9
panic({0x7ab540?, 0x8b7460?})
        /usr/local/go/src/runtime/panic.go:920 +0x270
github.com/kurusugawa-computer/freee-go/oauth.Authorize.func3.1({0x8bae50, 0xc0003387e0}, 0x0?)
        /home/vscode/go/pkg/mod/github.com/kurusugawa-computer/freee-go@v0.0.9-0.20240209055914-c96f3916a549/oauth/oauth.go:104 +0x2ab
net/http.HandlerFunc.ServeHTTP(0xb6d8c0?, {0x8bae50?, 0xc0003387e0?}, 0xc00007bb50?)
        /usr/local/go/src/net/http/server.go:2136 +0x29
net/http.serverHandler.ServeHTTP({0xc000204090?}, {0x8bae50?, 0xc0003387e0?}, 0x6?)
        /usr/local/go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc000208000, {0x8bb7c0, 0xc0000a9140})
        /usr/local/go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 6
        /usr/local/go/src/net/http/server.go:3086 +0x5cb
```