### PR TITLE
404ハンドラーの追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kurusugawa-computer/freee-go
 
 go 1.21.6
+
+require github.com/go-chi/chi/v5 v5.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=


### PR DESCRIPTION
### 目的
ブラウザーのデフォルト動作によって余分なリクエストが発生することがある。
これによって認証が失敗してしまう危険性を排除する。

### 変更点

- `/` 以外のリクエストに対して404を返却するハンドラーを追加

### 確認手順

- README.MDを参考にfreeeのセットアップを行う
- exampleをもとに認証プログラムを作成する
- 認証実行してエラーが発生しないことを確認する

### 備考
```go
if !errors.Is(err, http.ErrServerClosed) {
  // サーバー停止以外のエラーをエラーとする
  resultCh <- Result{"", err}
}
```
この部分について、認証リクエストが処理されてから、サーバーが停止するときにエラーが発生すると、閉じられたチャネルにエラーが流れ込んでしまいパニックになる可能性があるのではないかと疑っています。

### 確認事項

- [x] 修正途中であればDraftになっていますか？
- [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
- [ ] reviewer assignee は登録してありますか？