### PR TITLE
chiパッケージへの依存を削除

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/kurusugawa-computer/freee-go
 
 go 1.21.6
-
-require github.com/go-chi/chi/v5 v5.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
-github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -10,8 +10,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/go-chi/chi/v5"
 )
 
 type opt struct {
@@ -111,9 +109,15 @@ func Authorize(clientID string, port int, opts ...OptFunc) (string, error) {
 			http.Error(w, "Not Found", http.StatusNotFound)
 		})
 
-		mux := chi.NewRouter()
-		mux.Handle("/", authHandler)
-		mux.Handle("/*", notFoundHandler)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/":
+				authHandler.ServeHTTP(w, r)
+			default:
+				notFoundHandler.ServeHTTP(w, r)
+			}
+		})
 
 		server := &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),


### PR DESCRIPTION
### 目的
freee-go は OSS のライブラリでどこにも依存しないのがウリのひとつだったので、ちょっとしたルーティング程度であれば標準ライブラリで実施したい。
chi/v5 に依存していると、とくに gin や chi/v4 など使っている人にとって採用しづらくなってしまうので。

### 変更点

- chi -> httpパッケージへ変更

### 確認手順

- README.MDを参考にfreeeのセットアップを行う
- exampleをもとに認証プログラムを作成する
- 認証実行してエラーが発生しないことを確認する

### 備考

### 確認事項

- [x] 修正途中であればDraftになっていますか？
- [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
- [x] reviewer assignee は登録してありますか？